### PR TITLE
analyze dart code on the bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 with_content_shell: true
-script: pub run test -p content-shell -p firefox
+script: ./tool/travis.sh
 sudo: false
 dart:
   - stable

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright (c) 2015, Google Inc. Please see the AUTHORS file for details.
+# All rights reserved. Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -e
+
+# Verify that the libraries are error free.
+dartanalyzer --fatal-warnings \
+  lib/notification.dart \
+  test/notification_test.dart
+
+# Run the tests.
+pub run test -p content-shell -p firefox


### PR DESCRIPTION
Run `dartanalyzer` on the source code on the bot, as well as running the tests.

@alan-knight 
